### PR TITLE
Fix filters link that pointed on raw markdown files

### DIFF
--- a/Filters.md
+++ b/Filters.md
@@ -3,8 +3,6 @@
 Filters can be added to conduit connections to control what the conduit can insert or extract.
 They can be configured when installed (gear button) or by right-clicking them into the air.
 
-## [Item Filters](Item-Filters.md)
-
-## [Fluid Filters](Fluid-Filters.md)
-
-## [Redstone Filters](Redstone-Filters.md)
+* [[Item Filters]]
+* [[Fluid Filters]]
+* [[Redstone Filters]]


### PR DESCRIPTION
Based the syntax on the List-of-Conduits page, that is properly rendered in the wiki, but not when navigating to the page.